### PR TITLE
데드타임 구현 및 symmetric PWM으로 수정

### DIFF
--- a/pwm_phase_3.c
+++ b/pwm_phase_3.c
@@ -24,7 +24,7 @@ void PWMfreq(double freq) //freq[kHz]
     uint16_t PSC = 0;
     __HAL_TIM_SET_AUTORELOAD(&htim1, ARR_VALUE - 1); //set ARR to 500-1
 
-    PSC = (uint16_t)round(CLK_FREQ*2/ freq);
+    PSC = (uint16_t)round(CLK_FREQ*2/ (freq*2)); //for the symmetric PWM
     __HAL_TIM_SET_PRESCALER(&htim1, PSC - 1);
 }
 


### PR DESCRIPTION
1. PWM 데드타임 구현
  sBreakDeadTimeConfig.DeadTime = 128; //수정부분
과 같이 설정함으로써 128 * 타이머 주파수 (1/64M) = 2us 데드타임을 구현할 수 있음

2. symmetric PWM으로 수정
  htim1.Init.CounterMode = TIM_COUNTERMODE_CENTERALIGNED3; //수정부분
과 같이 설정함으로써 symmetric PWM 가능
또한 절반으로 감소한 주파수를 보정하기 위해, PWMfreq 함수의 PSC 설정 부분에서 입력된 주파수를 두배로 스케일링해줌